### PR TITLE
Benchmark Controller Return type

### DIFF
--- a/src/Controllers/BenchmarkController.cs
+++ b/src/Controllers/BenchmarkController.cs
@@ -45,7 +45,7 @@ namespace Ngsa.Application.Controllers
 
                 Logger.LogWarning(nameof(GetDataAsync), "Invalid Size", NgsaLog.LogEvent400, HttpContext);
 
-                return BadRequest("Invalid Size");
+                return ResultHandler.CreateResult(list, RequestLogger.GetPathAndQuerystring(Request));
             }
 
             if (size > 1024 * 1024)
@@ -61,7 +61,7 @@ namespace Ngsa.Application.Controllers
 
                 Logger.LogWarning(nameof(GetDataAsync), "Invalid Size", NgsaLog.LogEvent400, HttpContext);
 
-                return BadRequest("Invalid Size");
+                return ResultHandler.CreateResult(list, RequestLogger.GetPathAndQuerystring(Request));
             }
 
             if (App.Config.AppType == AppType.WebAPI)


### PR DESCRIPTION
BenchmarkController updates:

- application/problem+json content-type for invalid size
- Proper json error message

## Tests

- Tested with loderunner baseline and benchmark json files

## Closes

- Closes https://github.com/retaildevcrews/wcnp/issues/191