### PR TITLE
Upsert to Cosmos with payload size

### DIFF
--- a/src/Controllers/MoviesController.cs
+++ b/src/Controllers/MoviesController.cs
@@ -155,7 +155,9 @@ namespace Ngsa.Application.Controllers
                     {
                         if (upsertMovieQueryParameters.PayloadSize > 0)
                         {
-                            m.Payload = await App.Config.CacheDal.GetBenchmarkDataAsync(upsertMovieQueryParameters.PayloadSize);
+                            // insert payload in 1MB increments up to 2MB
+                            m.Payload = await App.Config.CacheDal.GetBenchmarkDataAsync(Math.Min(1024 * 1024, upsertMovieQueryParameters.PayloadSize));
+                            m.Payload += await App.Config.CacheDal.GetBenchmarkDataAsync(Math.Max(0, upsertMovieQueryParameters.PayloadSize - (1024 * 1024)));
                         }
 
                         try

--- a/src/DataAccessLayer/Model/Movie.cs
+++ b/src/DataAccessLayer/Model/Movie.cs
@@ -25,6 +25,7 @@ namespace Imdb.Model
         public string TextSearch { get; set; }
         public List<string> Genres { get; set; }
         public List<Role> Roles { get; set; }
+        public string Payload { get; set; }
 
         /// <summary>
         /// Compute the partition key based on the movieId or actorId
@@ -148,6 +149,7 @@ namespace Imdb.Model
                     new Int64Field("votes", Votes, Store.YES),
                     new DoubleField("rating", Rating, Store.YES),
                     new Int32Field("year", Year, Store.YES),
+                    new StringField("payload", Payload, Store.YES),
                 };
 
             if (Genres != null && Genres.Count > 0)

--- a/src/DataAccessLayer/Model/Movie.cs
+++ b/src/DataAccessLayer/Model/Movie.cs
@@ -25,7 +25,9 @@ namespace Imdb.Model
         public string TextSearch { get; set; }
         public List<string> Genres { get; set; }
         public List<Role> Roles { get; set; }
-        public string Payload { get; set; }
+        #nullable enable
+        public string? Payload { get; set; }
+        #nullable disable
 
         /// <summary>
         /// Compute the partition key based on the movieId or actorId
@@ -149,7 +151,6 @@ namespace Imdb.Model
                     new Int64Field("votes", Votes, Store.YES),
                     new DoubleField("rating", Rating, Store.YES),
                     new Int32Field("year", Year, Store.YES),
-                    new StringField("payload", Payload, Store.YES),
                 };
 
             if (Genres != null && Genres.Count > 0)
@@ -190,6 +191,11 @@ namespace Imdb.Model
 
             doc.Add(new TextField("content", GetContent(), Store.NO));
             doc.Add(new StoredField("json", JsonSerializer.SerializeToUtf8Bytes<Movie>(this)));
+
+            if (Payload != null)
+            {
+                doc.Add(new StringField("payload", Payload, Store.YES));
+            }
 
             return doc;
         }

--- a/src/DataAccessLayer/QueryParameters/UpsertMovieQueryParameters.cs
+++ b/src/DataAccessLayer/QueryParameters/UpsertMovieQueryParameters.cs
@@ -21,9 +21,10 @@ namespace Ngsa.Middleware
         {
             List<ValidationError> errors = new ();
 
-            if (PayloadSize > 1024 * 1024)
+            // Cosmos item size limit is 2MB
+            if (PayloadSize > 2048 * 1024)
             {
-                errors.Add(new ValidationError { Target = "payload size", Message = $"payload size must be <= 1 MB ({1024 * 1024})" });
+                errors.Add(new ValidationError { Target = "payload size", Message = $"payload size must be <= 2 MB ({2048 * 1024})" });
             }
             else if (PayloadSize < 0)
             {

--- a/src/DataAccessLayer/QueryParameters/UpsertMovieQueryParameters.cs
+++ b/src/DataAccessLayer/QueryParameters/UpsertMovieQueryParameters.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Collections.Generic;
+using Ngsa.Middleware.Validation;
+
+namespace Ngsa.Middleware
+{
+    /// <summary>
+    /// Query string parameters for PUT Movies controller method
+    /// </summary>
+    public sealed class UpsertMovieQueryParameters
+    {
+        public int PayloadSize { get; set; }
+
+        /// <summary>
+        /// Validate this object
+        /// </summary>
+        /// <returns>list of validation errors or empty list</returns>
+        public List<ValidationError> Validate()
+        {
+            List<ValidationError> errors = new ();
+
+            if (PayloadSize > 1024 * 1024)
+            {
+                errors.Add(new ValidationError { Target = "payload size", Message = $"payload size must be <= 1 MB ({1024 * 1024})" });
+            }
+            else if (PayloadSize < 0)
+            {
+                errors.Add(new ValidationError { Target = "payload size", Message = $"payload size must be >= 0" });
+            }
+
+
+            return errors;
+        }
+    }
+}


### PR DESCRIPTION
Update upsert method to write a movie with a payload size of up to 2MB (cosmos item limit)
Optional payload field for the movie model

Addresses: https://github.com/retaildevcrews/wcnp/issues/785