### PR TITLE
`emptyDir` mount at /tmp to fix pod crashing due to `readOnlyRootFilesystem: true`

### DIFF
--- a/autogitops/dev/ngsa-cosmos.yaml
+++ b/autogitops/dev/ngsa-cosmos.yaml
@@ -54,6 +54,8 @@ spec:
           volumeMounts:
             - name: secrets
               mountPath: "/app/secrets"
+            - mountPath: /tmp
+              name: tmp
           securityContext:
             readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false
@@ -67,6 +69,8 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       volumes:
+        - emptyDir: {}
+          name: tmp
         - name: secrets
           csi:
             driver: secrets-store.csi.k8s.io

--- a/autogitops/dev/ngsa-memory.yaml
+++ b/autogitops/dev/ngsa-memory.yaml
@@ -63,6 +63,12 @@ spec:
                 - ALL
             runAsNonRoot: true
             runAsUser: 10001
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+      volumes:
+        - emptyDir: {}
+          name: tmp
       automountServiceAccountToken: false
       securityContext:
         seccompProfile:


### PR DESCRIPTION
# Type of PR

- [X] Code changes
- [X] CI-CD changes

## Purpose of PR
NGSA was crashing when we added readOnlyRootFilesystem: true in YAML files.

### Reason
`dotnet run` writes FIFO diagnostics pipes to `/tmp` directory. `System.CommandLine` writes autocompletion helper files to `/tmp` directory as well. Since the file system is read only, the pods crashes when trying to create files/dirs.

### Solution
We are using `emptyDir` volume and mounting it at `/tmp` for each pod.

### NOTE on Access & Security
It was confirmed that the empty volumes are indeed ephemeral and is strictly tied to a single POD instance.

It cannot be used by other pods, and even if we use replicaSet (>1), each replica will have their own `emptyDir` volume.

### Removing dotnet FIFO diagnostic pipes
We did not remove FIPO pipes created by `dotnet run`. But, if necessary, we can add an environment variable `COMPlus_EnableDiagnostics=0` which will remove the diagnostic pipes.

 
## Does this introduce a breaking change

- [ ] YES
- [X] NO

## Validation

- [X] Unit tests updated and ran successfully

## Issues Closed or Referenced

- Closes https://github.com/retaildevcrews/wcnp/issues/788

