### PR TITLE
Add OpenTelemetry Tracing Header Propagation

### DIFF
--- a/Ngsa.App.csproj
+++ b/Ngsa.App.csproj
@@ -31,6 +31,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="OpenTelemetry" Version="1.3.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.3.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc9.3" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.3" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc9.3" />
     <PackageReference Include="prometheus-net.AspNetCore" Version="4.1.1" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20574.7" />
     <PackageReference Include="System.Runtime.Caching" Version="5.0.0" />

--- a/src/Handlers/RequestLogger/RequestLogger.cs
+++ b/src/Handlers/RequestLogger/RequestLogger.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Text.Json;
 using System.Threading.Tasks;
 using System.Web;
@@ -170,6 +171,8 @@ namespace Ngsa.Middleware
                     { "UserAgent", context.Request.Headers["User-Agent"].ToString() },
                     { "CVector", cv.Value },
                     { "CVectorBase", cv.GetBase() },
+                    { "TraceID", Activity.Current.Context.TraceId.ToString() },
+                    { "SpanID", Activity.Current.Context.SpanId.ToString() },
                     { "Category", category },
                     { "Subcategory", subCategory },
                     { "Mode", mode },

--- a/src/NgsaLogger/NgsaLogger.cs
+++ b/src/NgsaLogger/NgsaLogger.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Text.Json;
 using Microsoft.AspNetCore.Http;
@@ -105,6 +106,9 @@ namespace Ngsa.Middleware
                             {
                                 d.Add("CVector", cv.Value);
                             }
+
+                            d.Add("TraceID", Activity.Current.Context.TraceId.ToString());
+                            d.Add("TraceID", Activity.Current.Context.SpanId.ToString());
                         }
                     }
                     else

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -9,8 +9,11 @@ using System.IO;
 using System.Threading;
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Ngsa.Middleware;
+using OpenTelemetry;
+using OpenTelemetry.Context.Propagation;
 
 namespace Ngsa.Application
 {
@@ -160,6 +163,9 @@ namespace Ngsa.Application
                         .AddFilter("Ngsa.Application", Config.LogLevel);
                     }
                 });
+
+            builder.ConfigureServices(services => services.AddOpenTelemetryTracing());
+            Sdk.SetDefaultTextMapPropagator(new B3Propagator());
 
             // build the host
             return builder.Build();


### PR DESCRIPTION
# Type of PR

- [ ] Documentation changes
- [x] Code changes
- [ ] Test changes
- [x] CI-CD changes
- [ ] GitHub Template changes

## PR Checklist

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.
- [x] I ran lint checks locally prior to submission.
- [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

## Purpose of PR
Start replacement of MS-CV headers with opentelemetry supported standard. Specifically, b3 is being used as istio can automatically inject them. Relies on autoinstrumentation in the form of a java agent that is attached at runtime. Tested to make sure it doesn't impact performance. Removal of Correlation Vector will happen later.

<img width="1252" alt="image" src="https://user-images.githubusercontent.com/52010147/171458431-98e46b75-5a49-4666-97dc-51b089224646.png">


## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
## Validation

- [ ] Unit tests updated and ran successfully
- [ ] Update documentation or issue referenced above

## Issues Closed or Referenced

- Closes https://github.com/retaildevcrews/wcnp/issues/626
