### PR TITLE
Istio sidecar, limits for cosmos

### DIFF
--- a/autogitops/dev/ngsa-cosmos.yaml
+++ b/autogitops/dev/ngsa-cosmos.yaml
@@ -22,6 +22,12 @@ spec:
         app: {{gitops.name}}-cosmos
         deploy: {{gitops.deploy}}
         version: beta-{{gitops.version}}
+        sidecar.istio.io/inject: "true"
+      annotations:
+        sidecar.istio.io/proxyCPU: "50m"
+        sidecar.istio.io/proxyMemory: "128M"
+        sidecar.istio.io/proxyCPULimit: "500m"
+        sidecar.istio.io/proxyMemoryLimit: "256M"
     spec:
       containers:
         - name: app

--- a/autogitops/dev/ngsa-memory.yaml
+++ b/autogitops/dev/ngsa-memory.yaml
@@ -73,8 +73,6 @@ spec:
       securityContext:
         seccompProfile:
           type: RuntimeDefault
-      nodeSelector:
-        agentpool: npuser01
 
 ---
 apiVersion: v1

--- a/autogitops/preprod/ngsa-memory.yaml
+++ b/autogitops/preprod/ngsa-memory.yaml
@@ -68,8 +68,6 @@ spec:
       securityContext:
         seccompProfile:
           type: RuntimeDefault
-      nodeSelector:
-        agentpool: npuser01
 
 ---
 apiVersion: v1


### PR DESCRIPTION
# Type of PR

- [ ] Documentation changes
- [x] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## PR Checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code follows the code style of this project.
- [ ] I ran lint checks locally prior to submission.
- [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

## Purpose of PR
Enable istio sidecar for dev cosmos only
Add Istio sidecar requests/limits where sidecar deployed
Ngsa memory shouldn't use npuser01 node

## Does this introduce a breaking change

- [ ] YES
- [x] NO

## Issues Closed or Referenced
- References https://github.com/retaildevcrews/wcnp/issues/1016
