### PR TITLE
point dev: ngsa-cosmos pod count is not stable in preprod central

### DIFF
--- a/autogitops/dev/ngsa-cosmos.yaml
+++ b/autogitops/dev/ngsa-cosmos.yaml
@@ -48,8 +48,7 @@ spec:
               containerPort: 8080
               protocol: TCP
           readinessProbe:
-            initialDelaySeconds: 30
-            timeoutSeconds: 120
+            initialDelaySeconds: 5
             httpGet:
               path: /version
               port: 8080

--- a/autogitops/dev/ngsa-cosmos.yaml
+++ b/autogitops/dev/ngsa-cosmos.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     app.kubernetes.io/name: {{gitops.name}}-cosmos
 spec:
-  replicas: 2
   selector:
     matchLabels:
       app: {{gitops.name}}-cosmos
@@ -49,7 +48,8 @@ spec:
               containerPort: 8080
               protocol: TCP
           readinessProbe:
-            initialDelaySeconds: 5
+            initialDelaySeconds: 30
+            timeoutSeconds: 120
             httpGet:
               path: /version
               port: 8080

--- a/autogitops/preprod/ngsa-cosmos.yaml
+++ b/autogitops/preprod/ngsa-cosmos.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     app.kubernetes.io/name: {{gitops.name}}-cosmos
 spec:
-  replicas: 2
   selector:
     matchLabels:
       app: {{gitops.name}}-cosmos
@@ -39,7 +38,8 @@ spec:
               containerPort: 8080
               protocol: TCP
           readinessProbe:
-            initialDelaySeconds: 5
+            initialDelaySeconds: 30
+            timeoutSeconds: 120
             httpGet:
               path: /version
               port: 8080

--- a/autogitops/preprod/ngsa-cosmos.yaml
+++ b/autogitops/preprod/ngsa-cosmos.yaml
@@ -38,8 +38,7 @@ spec:
               containerPort: 8080
               protocol: TCP
           readinessProbe:
-            initialDelaySeconds: 30
-            timeoutSeconds: 120
+            initialDelaySeconds: 5
             httpGet:
               path: /version
               port: 8080


### PR DESCRIPTION
# Type of PR

- [ ] Documentation changes
- [x] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## PR Checklist

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] My code follows the code style of this project.
- [ ] I ran lint checks locally prior to submission.
- [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

## Purpose of PR
Fix instability of ngsa-cosmos pods to ensure stable deployment of applications.

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
## Validation

- [ ] Unit tests updated and ran successfully
- [ ] Update documentation or issue referenced above

## Issues Closed or Referenced

- References https://github.com/retaildevcrews/wcnp/issues/1038
