### PR TITLE
Enable Cosmos to use Managed Identity - 1051

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -309,5 +309,3 @@ dist
 ### OSX ###
 # General
 .DS_Store
-/Ngsa.App.sln
-.gitignore

--- a/.gitignore
+++ b/.gitignore
@@ -309,3 +309,5 @@ dist
 ### OSX ###
 # General
 .DS_Store
+/Ngsa.App.sln
+.gitignore

--- a/Ngsa.App.csproj
+++ b/Ngsa.App.csproj
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.9.0-beta.1" />
+    <PackageReference Include="Azure.Identity" Version="1.7.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="OpenTelemetry" Version="1.3.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.3.0-beta.1" />

--- a/Ngsa.App.csproj
+++ b/Ngsa.App.csproj
@@ -32,6 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Identity" Version="1.9.0-beta.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="OpenTelemetry" Version="1.3.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.3.0-beta.1" />

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Options:
   -r, --region <region>                                                            Region for log [default: dev]
   -l, --log-level <Critical|Debug|Error|Information|None|Trace|Warning>            Log Level [default: Error]
   -q, --request-log-level <Critical|Debug|Error|Information|None|Trace|Warning>    Request Log Level [default: Information]
-  --use-mi-for-cosmos                                                              Use Managed Idendity to authenticate CosmosDB
+  -c, --cosmos-auth-type <ManagedIdentity|SecretKey>                               CosmosDB Authentication type [default: SecretKey]
   --dry-run                                                                        Validates configuration
   --version                                                                        Show version information
   -?, -h, --help                                                                   Show help and usage information

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Options:
   -r, --region <region>                                                            Region for log [default: dev]
   -l, --log-level <Critical|Debug|Error|Information|None|Trace|Warning>            Log Level [default: Error]
   -q, --request-log-level <Critical|Debug|Error|Information|None|Trace|Warning>    Request Log Level [default: Information]
+  --use-mi-for-cosmos                                                              Use Managed Idendity to authenticate CosmosDB
   --dry-run                                                                        Validates configuration
   --version                                                                        Show version information
   -?, -h, --help                                                                   Show help and usage information

--- a/README.md
+++ b/README.md
@@ -76,6 +76,23 @@ For ease of debugging, a launch.json file can be created in the .vscode director
 
 --cosmos-auth-type has two potential values; ManagedIdentity and Secret.  If set to Secret, a secret key must be provided in the secrets directory.
 
+If a user is testing locally there is not the option to use Managed Identity.  To move past this the following commands can be used to add the user in question to the correct Cosmos groups
+In bash add your own AAD user to CosmosDB:
+
+```bash
+# Get your own Principal ID (replace the email with yours)
+export PRINCIPAL=$(az ad user show --id YOUR-MSFT-ID@microsoft.com --query 'id' -o tsv)
+
+export COSMOS_RG=rg-ngsa-asb-dev-cosmos
+export COSMOS_NAME=ngsa-asb-dev-cosmos
+export COSMOS_SCOPE=$(az cosmosdb show -g $COSMOS_RG -n $COSMOS_NAME --query id -o tsv)
+
+# Add yourself to CosmosDB SQL Access
+az cosmosdb sql role assignment create -g $COSMOS_RG --account-name $COSMOS_NAME --role-definition-id 00000000-0000-0000-0000-000000000001 --principal-id $PRINCIPAL --scope $COSMOS_SCOPE
+az cosmosdb sql role assignment create -g $COSMOS_RG --account-name $COSMOS_NAME --role-definition-id 00000000-0000-0000-0000-000000000002 --principal-id $PRINCIPAL --scope $COSMOS_SCOPE
+```
+
+
 ### Using bash shell
 
 > This will work from a terminal in Visual Studio Codespaces as well

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # NGSA App
 
-NGSA App is inteneded for platform testing and monitoring in one or many Kubernetes clusters and/or cloud deployments.
+NGSA App is intended for platform testing and monitoring in one or many Kubernetes clusters and/or cloud deployments.
 
 ## Prerequisites
 
@@ -10,6 +10,7 @@ NGSA App is inteneded for platform testing and monitoring in one or many Kuberne
 - Docker CLI ([download](https://docs.docker.com/install/))
 - .NET 5.0 ([download](https://docs.microsoft.com/en-us/dotnet/core/install/))
 - Visual Studio Code (optional) ([download](https://code.visualstudio.com/download))
+- Visual Studio 2022 (optional)  - Must export the AZURE_TENANT_ID value to an environment variable.
 
 ## Ngsa-app Usage
 
@@ -54,6 +55,27 @@ To open with codespaces:
 - Click `New Codespace`
 - Choose the `4 core` option
 
+Prior to running the application in Visual Studio Codespaces, use the command below to authenticate:
+
+```bash
+
+# These two values can be obtained from the Azure Portal
+local tenantId = ''
+local subscriptionId = ''
+
+az login --tenant $tenantId
+az account set --subscription $subscriptionId
+
+```
+
+The code above is uses to establish Azure credentials, and specify which tenant and subscription should be utilized for the execution.
+
+For ease of debugging, a launch.json file can be created in the .vscode directory, if there is one already created it can be modified with the following value:
+
+ "args": ["--cosmos-auth-type=ManagedIdentity"],
+
+--cosmos-auth-type has two potential values; ManagedIdentity and Secret.  If set to Secret, a secret key must be provided in the secrets directory.
+
 ### Using bash shell
 
 > This will work from a terminal in Visual Studio Codespaces as well
@@ -93,7 +115,7 @@ Open a new bash shell
 
 # test the application
 
-# test using httpie (installed automatically in Codespaces)
+# test using http ie (installed automatically in Codespaces)
 http localhost:8080/version
 
 # test using curl
@@ -102,6 +124,7 @@ curl localhost:8080/version
 ```
 
 Stop ngsa by typing Ctrl-C or the stop button if run via F5
+
 ## Autogitops
 
 The Ngsa application when running as `--in-memory` mode, utilizes its built-in data storage, so having more than one replica deployed into a cluster will cause each `pod` to have its own local data storage. As a result, requests made to ngsa app endpoints will be managed by the default `load balancer` and can end up at a different `pod` each time where data requested may or may not exist returning unexpected error codes.

--- a/README.md
+++ b/README.md
@@ -105,7 +105,9 @@ Stop ngsa by typing Ctrl-C or the stop button if run via F5
 
 ### [Alternative to secrets] Visual Studio: CosmosDB access using Identity
 
-In bash add your own AAD user to CosmosDB:
+Below will illistrate how to add your user's principal Id to the correct group so that local development can take advantage of the managed identity.  
+
+In bash add your AAD user to CosmosDB:
 
 ```bash
 # Get your own Principal ID (replace the email with yours)
@@ -119,8 +121,6 @@ export COSMOS_SCOPE=$(az cosmosdb show -g $COSMOS_RG -n $COSMOS_NAME --query id 
 az cosmosdb sql role assignment create -g $COSMOS_RG --account-name $COSMOS_NAME --role-definition-id 00000000-0000-0000-0000-000000000002 --principal-id $PRINCIPAL --scope $COSMOS_SCOPE
 
 ```
-
-Add `--use-mi-for-cosmos` arg for debugging
 
 ## Autogitops
 

--- a/README.md
+++ b/README.md
@@ -102,26 +102,6 @@ curl localhost:8080/version
 ```
 
 Stop ngsa by typing Ctrl-C or the stop button if run via F5
-
-### [Alternative to secrets] Visual Studio: CosmosDB access using Identity
-
-Below will illustrate how to add your user's principal Id to the correct group so that local development can take advantage of the managed identity.
-
-In bash add your AAD user to CosmosDB:
-
-```bash
-# Get your own Principal ID (replace the email with yours)
-export PRINCIPAL=$(az ad user show --id YOUR-MSFT-ID@microsoft.com --query 'id' -o tsv)
-
-export COSMOS_RG=rg-ngsa-asb-dev-cosmos
-export COSMOS_NAME=ngsa-asb-dev-cosmos
-export COSMOS_SCOPE=$(az cosmosdb show -g $COSMOS_RG -n $COSMOS_NAME --query id -o tsv)
-
-# Add yourself to CosmosDB SQL Access
-az cosmosdb sql role assignment create -g $COSMOS_RG --account-name $COSMOS_NAME --role-definition-id 00000000-0000-0000-0000-000000000002 --principal-id $PRINCIPAL --scope $COSMOS_SCOPE
-
-```
-
 ## Autogitops
 
 The Ngsa application when running as `--in-memory` mode, utilizes its built-in data storage, so having more than one replica deployed into a cluster will cause each `pod` to have its own local data storage. As a result, requests made to ngsa app endpoints will be managed by the default `load balancer` and can end up at a different `pod` each time where data requested may or may not exist returning unexpected error codes.

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Stop ngsa by typing Ctrl-C or the stop button if run via F5
 
 ### [Alternative to secrets] Visual Studio: CosmosDB access using Identity
 
-Below will illistrate how to add your user's principal Id to the correct group so that local development can take advantage of the managed identity.  
+Below will illustrate how to add your user's principal Id to the correct group so that local development can take advantage of the managed identity.
 
 In bash add your AAD user to CosmosDB:
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,25 @@ curl localhost:8080/version
 
 Stop ngsa by typing Ctrl-C or the stop button if run via F5
 
+### [Alternative to secrets] Visual Studio: CosmosDB access using Identity
+
+In bash add your own AAD user to CosmosDB:
+
+```bash
+# Get your own Principal ID (replace the email with yours)
+export PRINCIPAL=$(az ad user show --id YOUR-MSFT-ID@microsoft.com --query 'id' -o tsv)
+
+export COSMOS_RG=rg-ngsa-asb-dev-cosmos
+export COSMOS_NAME=ngsa-asb-dev-cosmos
+export COSMOS_SCOPE=$(az cosmosdb show -g $COSMOS_RG -n $COSMOS_NAME --query id -o tsv)
+
+# Add yourself to CosmosDB SQL Access
+az cosmosdb sql role assignment create -g $COSMOS_RG --account-name $COSMOS_NAME --role-definition-id 00000000-0000-0000-0000-000000000002 --principal-id $PRINCIPAL --scope $COSMOS_SCOPE
+
+```
+
+Add `--use-mi-for-cosmos` arg for debugging
+
 ## Autogitops
 
 The Ngsa application when running as `--in-memory` mode, utilizes its built-in data storage, so having more than one replica deployed into a cluster will cause each `pod` to have its own local data storage. As a result, requests made to ngsa app endpoints will be managed by the default `load balancer` and can end up at a different `pod` each time where data requested may or may not exist returning unexpected error codes.

--- a/README.md
+++ b/README.md
@@ -88,7 +88,6 @@ export COSMOS_NAME=ngsa-asb-dev-cosmos
 export COSMOS_SCOPE=$(az cosmosdb show -g $COSMOS_RG -n $COSMOS_NAME --query id -o tsv)
 
 # Add yourself to CosmosDB SQL Access
-az cosmosdb sql role assignment create -g $COSMOS_RG --account-name $COSMOS_NAME --role-definition-id 00000000-0000-0000-0000-000000000001 --principal-id $PRINCIPAL --scope $COSMOS_SCOPE
 az cosmosdb sql role assignment create -g $COSMOS_RG --account-name $COSMOS_NAME --role-definition-id 00000000-0000-0000-0000-000000000002 --principal-id $PRINCIPAL --scope $COSMOS_SCOPE
 ```
 

--- a/autogitops/dev/ngsa-cosmos.yaml
+++ b/autogitops/dev/ngsa-cosmos.yaml
@@ -43,6 +43,7 @@ spec:
           - {{gitops.config.zone}}
           - --region
           - {{gitops.config.region}}
+          - --use-mi-for-cosmos
           ports:
             - name: http
               containerPort: 8080

--- a/autogitops/dev/ngsa-cosmos.yaml
+++ b/autogitops/dev/ngsa-cosmos.yaml
@@ -43,7 +43,8 @@ spec:
           - {{gitops.config.zone}}
           - --region
           - {{gitops.config.region}}
-          - --use-mi-for-cosmos
+          - --cosmos-auth-type
+          - ManagedIdentity
           ports:
             - name: http
               containerPort: 8080

--- a/autogitops/preprod/ngsa-cosmos.yaml
+++ b/autogitops/preprod/ngsa-cosmos.yaml
@@ -33,6 +33,7 @@ spec:
           - {{gitops.config.zone}}
           - --region
           - {{gitops.config.region}}
+          - --use-mi-for-cosmos
           ports:
             - name: http
               containerPort: 8080

--- a/autogitops/preprod/ngsa-cosmos.yaml
+++ b/autogitops/preprod/ngsa-cosmos.yaml
@@ -33,7 +33,8 @@ spec:
           - {{gitops.config.zone}}
           - --region
           - {{gitops.config.region}}
-          - --use-mi-for-cosmos
+          - --cosmos-auth-type
+          - ManagedIdentity
           ports:
             - name: http
               containerPort: 8080

--- a/deploy/ngsa-cosmos.yaml
+++ b/deploy/ngsa-cosmos.yaml
@@ -27,6 +27,8 @@ spec:
           - dev
           - --region
           - dev
+          - --cosmos-auth-type
+          - ManagedIdentity
           ports:
             - name: http
               containerPort: 8080

--- a/secrets/CosmosUrl
+++ b/secrets/CosmosUrl
@@ -1,1 +1,1 @@
-https://ngsa-asb-dev-cosmos.documents.azure.com:443/
+https://wcnp-dev-cosmos.documents.azure.com:443/

--- a/src/Core/CommandLine.cs
+++ b/src/Core/CommandLine.cs
@@ -135,7 +135,6 @@ namespace Ngsa.Application
                 string urlPrefix = result.Children.FirstOrDefault(c => c.Symbol.Name == "urlPrefix") is OptionResult urlRes ? urlRes.GetValueOrDefault<string>() : string.Empty;
                 bool inMemory = result.Children.FirstOrDefault(c => c.Symbol.Name == "in-memory") is OptionResult inMemoryRes && inMemoryRes.GetValueOrDefault<bool>();
                 bool noCache = result.Children.FirstOrDefault(c => c.Symbol.Name == "no-cache") is OptionResult noCacheRes && noCacheRes.GetValueOrDefault<bool>();
-                bool useMI = result.Children.FirstOrDefault(c => c.Symbol.Name == "use-mi-for-cosmos") is OptionResult useMIRes && useMIRes.GetValueOrDefault<bool>();
 
                 // validate url-prefix
                 if (!string.IsNullOrWhiteSpace(urlPrefix))
@@ -211,12 +210,6 @@ namespace Ngsa.Application
                 if (inMemory && noCache)
                 {
                     msg += "--in-memory and --no-cache are exclusive\n";
-                }
-
-                // invalid combination
-                if (inMemory && useMI)
-                {
-                    msg += "--in-memory and --use-mi-for-cosmos are exclusive\n";
                 }
             }
             catch

--- a/src/Core/CommandLine.cs
+++ b/src/Core/CommandLine.cs
@@ -107,6 +107,7 @@ namespace Ngsa.Application
             root.AddOption(EnvVarOption(new string[] { "--log-level", "-l" }, "Log Level", LogLevel.Error));
             root.AddOption(EnvVarOption(new string[] { "--request-log-level", "-q" }, "Request Log Level", LogLevel.Information));
             root.AddOption(new Option<bool>(new string[] { "--dry-run" }, "Validates configuration"));
+            root.AddOption(new Option<bool>(new string[] { "--use-mi" }, "Use Managed Identity to access CosmosDB"));
 
             // validate dependencies
             root.AddValidator(ValidateDependencies);

--- a/src/Core/CommandLine.cs
+++ b/src/Core/CommandLine.cs
@@ -108,7 +108,7 @@ namespace Ngsa.Application
             root.AddOption(EnvVarOption(new string[] { "--log-level", "-l" }, "Log Level", LogLevel.Error));
             root.AddOption(EnvVarOption(new string[] { "--request-log-level", "-q" }, "Request Log Level", LogLevel.Information));
             root.AddOption(new Option<bool>(new string[] { "--dry-run" }, "Validates configuration"));
-            root.AddOption(EnvVarOption(new string[] { "--use-secret-key", "-k" }, "Cosmos Auth Type", CosmosAuthType.SecretKey));
+            root.AddOption(new Option<bool>(new string[] { "--use-secret-key" }, "Use SecretKey to authenticate CosmosDB"));
 
             // validate dependencies
             root.AddValidator(ValidateDependencies);
@@ -375,6 +375,11 @@ namespace Ngsa.Application
             // create data access layer
             if (Config.AppType == AppType.App)
             {
+                CosmosAuthType cosmosAuthType = config.UseSecretKey == false ? CosmosAuthType.ManagedIdentity : CosmosAuthType.SecretKey;
+
+                // Class level variable for global access
+                Config.CosmosAuthType = cosmosAuthType;
+                Config.UseSecretKey = config.UseSecretKey;
                 LoadSecrets();
 
                 // load the cache

--- a/src/Core/CommandLine.cs
+++ b/src/Core/CommandLine.cs
@@ -108,7 +108,7 @@ namespace Ngsa.Application
             root.AddOption(EnvVarOption(new string[] { "--log-level", "-l" }, "Log Level", LogLevel.Error));
             root.AddOption(EnvVarOption(new string[] { "--request-log-level", "-q" }, "Request Log Level", LogLevel.Information));
             root.AddOption(new Option<bool>(new string[] { "--dry-run" }, "Validates configuration"));
-            root.AddOption(new Option<bool>(new string[] { "--use-secret-key" }, "Use SecretKey to authenticate CosmosDB"));
+            root.AddOption(new Option<bool>(new string[] { "--use-mi-for-cosmos" }, "Use Managed Idendity to authenticate CosmosDB"));
 
             // validate dependencies
             root.AddValidator(ValidateDependencies);
@@ -375,11 +375,11 @@ namespace Ngsa.Application
             // create data access layer
             if (Config.AppType == AppType.App)
             {
-                CosmosAuthType cosmosAuthType = config.UseSecretKey == false ? CosmosAuthType.ManagedIdentity : CosmosAuthType.SecretKey;
+                CosmosAuthType cosmosAuthType = config.UseMIForCosmos == true ? CosmosAuthType.ManagedIdentity : CosmosAuthType.SecretKey;
 
                 // Class level variable for global access
                 Config.CosmosAuthType = cosmosAuthType;
-                Config.UseSecretKey = config.UseSecretKey;
+                Config.UseMIForCosmos = config.UseMIForCosmos;
                 LoadSecrets();
 
                 // load the cache

--- a/src/Core/CommandLine.cs
+++ b/src/Core/CommandLine.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Lucene.Net.Search;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Logging;
 using Ngsa.Middleware;
@@ -107,7 +108,7 @@ namespace Ngsa.Application
             root.AddOption(EnvVarOption(new string[] { "--log-level", "-l" }, "Log Level", LogLevel.Error));
             root.AddOption(EnvVarOption(new string[] { "--request-log-level", "-q" }, "Request Log Level", LogLevel.Information));
             root.AddOption(new Option<bool>(new string[] { "--dry-run" }, "Validates configuration"));
-            root.AddOption(new Option<bool>(new string[] { "--use-mi" }, "Use Managed Identity to access CosmosDB"));
+            root.AddOption(EnvVarOption(new string[] { "--use-secret-key", "-k" }, "Cosmos Auth Type", CosmosAuthType.SecretKey));
 
             // validate dependencies
             root.AddValidator(ValidateDependencies);
@@ -129,6 +130,11 @@ namespace Ngsa.Application
             {
                 // get the values to validate
                 AppType appType = result.Children.FirstOrDefault(c => c.Symbol.Name == "app-type") is OptionResult appTypeRes ? appTypeRes.GetValueOrDefault<AppType>() : AppType.App;
+
+                //TODO:  Discuss if any validation is needed
+
+                //CosmosAuthType cosmosAuthType = result.Children.FirstOrDefault(c => c.Symbol.Name == "use-secret-key") is OptionResult cosmosAuthTypeRes ? cosmosAuthTypeRes.GetValueOrDefault<CosmosAuthType>() : CosmosAuthType.SecretKey;
+
                 string secrets = result.Children.FirstOrDefault(c => c.Symbol.Name == "secrets-volume") is OptionResult secretsRes ? secretsRes.GetValueOrDefault<string>() : string.Empty;
                 string dataService = result.Children.FirstOrDefault(c => c.Symbol.Name == "data-service") is OptionResult dsRes ? dsRes.GetValueOrDefault<string>() : string.Empty;
                 string urlPrefix = result.Children.FirstOrDefault(c => c.Symbol.Name == "urlPrefix") is OptionResult urlRes ? urlRes.GetValueOrDefault<string>() : string.Empty;

--- a/src/Core/CommandLine.cs
+++ b/src/Core/CommandLine.cs
@@ -107,8 +107,8 @@ namespace Ngsa.Application
             root.AddOption(EnvVarOption(new string[] { "--region", "-r" }, "Region for log", "dev"));
             root.AddOption(EnvVarOption(new string[] { "--log-level", "-l" }, "Log Level", LogLevel.Error));
             root.AddOption(EnvVarOption(new string[] { "--request-log-level", "-q" }, "Request Log Level", LogLevel.Information));
-            root.AddOption(new Option<bool>(new string[] { "--dry-run" }, "Validates configuration"));
             root.AddOption(new Option<bool>(new string[] { "--use-mi-for-cosmos" }, "Use Managed Idendity to authenticate CosmosDB"));
+            root.AddOption(new Option<bool>(new string[] { "--dry-run" }, "Validates configuration"));
 
             // validate dependencies
             root.AddValidator(ValidateDependencies);
@@ -140,6 +140,7 @@ namespace Ngsa.Application
                 string urlPrefix = result.Children.FirstOrDefault(c => c.Symbol.Name == "urlPrefix") is OptionResult urlRes ? urlRes.GetValueOrDefault<string>() : string.Empty;
                 bool inMemory = result.Children.FirstOrDefault(c => c.Symbol.Name == "in-memory") is OptionResult inMemoryRes && inMemoryRes.GetValueOrDefault<bool>();
                 bool noCache = result.Children.FirstOrDefault(c => c.Symbol.Name == "no-cache") is OptionResult noCacheRes && noCacheRes.GetValueOrDefault<bool>();
+                bool useMI = result.Children.FirstOrDefault(c => c.Symbol.Name == "use-mi-for-cosmos") is OptionResult useMIRes && useMIRes.GetValueOrDefault<bool>();
 
                 // validate url-prefix
                 if (!string.IsNullOrWhiteSpace(urlPrefix))
@@ -215,6 +216,12 @@ namespace Ngsa.Application
                 if (inMemory && noCache)
                 {
                     msg += "--in-memory and --no-cache are exclusive\n";
+                }
+
+                // invalid combination
+                if (inMemory && useMI)
+                {
+                    msg += "--in-memory and --use-mi-for-cosmos are exclusive\n";
                 }
             }
             catch

--- a/src/Core/CommandLine.cs
+++ b/src/Core/CommandLine.cs
@@ -9,7 +9,6 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Lucene.Net.Search;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Logging;
 using Ngsa.Middleware;
@@ -130,10 +129,6 @@ namespace Ngsa.Application
             {
                 // get the values to validate
                 AppType appType = result.Children.FirstOrDefault(c => c.Symbol.Name == "app-type") is OptionResult appTypeRes ? appTypeRes.GetValueOrDefault<AppType>() : AppType.App;
-
-                //TODO:  Discuss if any validation is needed
-
-                //CosmosAuthType cosmosAuthType = result.Children.FirstOrDefault(c => c.Symbol.Name == "use-secret-key") is OptionResult cosmosAuthTypeRes ? cosmosAuthTypeRes.GetValueOrDefault<CosmosAuthType>() : CosmosAuthType.SecretKey;
 
                 string secrets = result.Children.FirstOrDefault(c => c.Symbol.Name == "secrets-volume") is OptionResult secretsRes ? secretsRes.GetValueOrDefault<string>() : string.Empty;
                 string dataService = result.Children.FirstOrDefault(c => c.Symbol.Name == "data-service") is OptionResult dsRes ? dsRes.GetValueOrDefault<string>() : string.Empty;

--- a/src/Core/CommandLine.cs
+++ b/src/Core/CommandLine.cs
@@ -106,7 +106,7 @@ namespace Ngsa.Application
             root.AddOption(EnvVarOption(new string[] { "--region", "-r" }, "Region for log", "dev"));
             root.AddOption(EnvVarOption(new string[] { "--log-level", "-l" }, "Log Level", LogLevel.Error));
             root.AddOption(EnvVarOption(new string[] { "--request-log-level", "-q" }, "Request Log Level", LogLevel.Information));
-            root.AddOption(new Option<bool>(new string[] { "--use-mi-for-cosmos" }, "Use Managed Idendity to authenticate CosmosDB"));
+            root.AddOption(EnvVarOption(new string[] { "--cosmos-auth-type", "-c" }, "CosmosDB Authentication type", CosmosAuthType.SecretKey));
             root.AddOption(new Option<bool>(new string[] { "--dry-run" }, "Validates configuration"));
 
             // validate dependencies
@@ -377,11 +377,8 @@ namespace Ngsa.Application
             // create data access layer
             if (Config.AppType == AppType.App)
             {
-                CosmosAuthType cosmosAuthType = config.UseMIForCosmos == true ? CosmosAuthType.ManagedIdentity : CosmosAuthType.SecretKey;
-
                 // Class level variable for global access
-                Config.CosmosAuthType = cosmosAuthType;
-                Config.UseMIForCosmos = config.UseMIForCosmos;
+                Config.CosmosAuthType = config.CosmosAuthType;
                 LoadSecrets();
 
                 // load the cache

--- a/src/Core/Config.cs
+++ b/src/Core/Config.cs
@@ -24,7 +24,7 @@ namespace Ngsa.Application
         /// <summary>
         /// Secrets specified in files type.
         /// </summary>
-        Secrets,
+        SecretKey,
 
         /// <summary>
         /// Managed Identity auth type.
@@ -42,7 +42,7 @@ namespace Ngsa.Application
         public string CosmosName { get; set; } = string.Empty;
         public bool IsLogLevelSet { get; set; }
         public Secrets Secrets { get; set; }
-        public CosmosAuthType CosmosAuthType { get; set; } = CosmosAuthType.Secrets;
+        public CosmosAuthType CosmosAuthType { get; set; } = CosmosAuthType.ManagedIdentity;
         public bool DryRun { get; set; }
         public bool InMemory { get; set; }
         public bool Cache => !NoCache;

--- a/src/Core/Config.cs
+++ b/src/Core/Config.cs
@@ -19,6 +19,20 @@ namespace Ngsa.Application
         WebAPI,
     }
 
+    public enum CosmosAuthType
+    {
+        /// <summary>
+        /// Secrets specified in files type.
+        /// </summary>
+        Secrets,
+
+        /// <summary>
+        /// Managed Identity auth type.
+        /// </summary>
+        ManagedIdentity,
+    }
+
+
     public class Config
     {
         public AppType AppType { get; set; } = AppType.App;
@@ -28,6 +42,7 @@ namespace Ngsa.Application
         public string CosmosName { get; set; } = string.Empty;
         public bool IsLogLevelSet { get; set; }
         public Secrets Secrets { get; set; }
+        public CosmosAuthType CosmosAuthType { get; set; } = CosmosAuthType.Secrets;
         public bool DryRun { get; set; }
         public bool InMemory { get; set; }
         public bool Cache => !NoCache;

--- a/src/Core/Config.cs
+++ b/src/Core/Config.cs
@@ -42,7 +42,6 @@ namespace Ngsa.Application
         public string CosmosName { get; set; } = string.Empty;
         public bool IsLogLevelSet { get; set; }
         public Secrets Secrets { get; set; }
-        public bool UseMIForCosmos { get; set; } = false;
         public CosmosAuthType CosmosAuthType { get; set; } = CosmosAuthType.SecretKey;
         public bool DryRun { get; set; }
         public bool InMemory { get; set; }

--- a/src/Core/Config.cs
+++ b/src/Core/Config.cs
@@ -42,6 +42,7 @@ namespace Ngsa.Application
         public string CosmosName { get; set; } = string.Empty;
         public bool IsLogLevelSet { get; set; }
         public Secrets Secrets { get; set; }
+        public bool UseSecretKey { get; set; } = false;
         public CosmosAuthType CosmosAuthType { get; set; } = CosmosAuthType.ManagedIdentity;
         public bool DryRun { get; set; }
         public bool InMemory { get; set; }

--- a/src/Core/Config.cs
+++ b/src/Core/Config.cs
@@ -42,7 +42,7 @@ namespace Ngsa.Application
         public string CosmosName { get; set; } = string.Empty;
         public bool IsLogLevelSet { get; set; }
         public Secrets Secrets { get; set; }
-        public CosmosAuthType CosmosAuthType { get; set; } = CosmosAuthType.SecretKey;
+        public CosmosAuthType CosmosAuthType { get; set; }
         public bool DryRun { get; set; }
         public bool InMemory { get; set; }
         public bool Cache => !NoCache;

--- a/src/Core/Config.cs
+++ b/src/Core/Config.cs
@@ -42,8 +42,8 @@ namespace Ngsa.Application
         public string CosmosName { get; set; } = string.Empty;
         public bool IsLogLevelSet { get; set; }
         public Secrets Secrets { get; set; }
-        public bool UseSecretKey { get; set; } = false;
-        public CosmosAuthType CosmosAuthType { get; set; } = CosmosAuthType.ManagedIdentity;
+        public bool UseMIForCosmos { get; set; } = false;
+        public CosmosAuthType CosmosAuthType { get; set; } = CosmosAuthType.SecretKey;
         public bool DryRun { get; set; }
         public bool InMemory { get; set; }
         public bool Cache => !NoCache;

--- a/src/Core/Secrets.cs
+++ b/src/Core/Secrets.cs
@@ -30,7 +30,7 @@ namespace Ngsa.Application
                 throw new ArgumentNullException(nameof(volume));
             }
 
-            // thow exception if volume doesn't exist
+            // throw exception if volume doesn't exist
             if (!Directory.Exists(volume))
             {
                 throw new Exception($"Volume '{volume}' does not exist");

--- a/src/DataAccessLayer/dalMain.cs
+++ b/src/DataAccessLayer/dalMain.cs
@@ -79,7 +79,7 @@ namespace Ngsa.Application.DataAccessLayer
         /// <param name="cosmosCollection">Cosmos Collection</param>
         /// <param name="cosmosAuthType">CosmosDB Auth type</param>
         /// <returns>An open and validated CosmosClient</returns>
-        private async Task<CosmosClient> OpenAndTestCosmosClient(string cosmosServer, string cosmosKey, string cosmosDatabase, string cosmosCollection, CosmosAuthType cosmosAuthType = CosmosAuthType.Secrets)
+        private async Task<CosmosClient> OpenAndTestCosmosClient(string cosmosServer, string cosmosKey, string cosmosDatabase, string cosmosCollection, CosmosAuthType cosmosAuthType = CosmosAuthType.SecretKey)
         {
             // TODO: Do we want to have optional/default values for cosmosAuthType, since its a private method?
             // validate required parameters
@@ -105,7 +105,7 @@ namespace Ngsa.Application.DataAccessLayer
 
             CosmosClient c = cosmosAuthType switch
             {
-                CosmosAuthType.Secrets => new(cosmosServer, cosmosKey, cosmosDetails.CosmosClientOptions),
+                CosmosAuthType.SecretKey => new(cosmosServer, cosmosKey, cosmosDetails.CosmosClientOptions),
                 CosmosAuthType.ManagedIdentity or _ => new(cosmosServer, new DefaultAzureCredential(), cosmosDetails.CosmosClientOptions),
             };
 

--- a/src/DataAccessLayer/dalMain.cs
+++ b/src/DataAccessLayer/dalMain.cs
@@ -33,7 +33,6 @@ namespace Ngsa.Application.DataAccessLayer
                 throw new ArgumentNullException(nameof(secrets));
             }
 
-            // TODO: Should we put the CosmosAuthType enum in CosmosConfig??
             cosmosDetails = new CosmosConfig
             {
                 CosmosCollection = secrets.CosmosCollection,
@@ -80,9 +79,7 @@ namespace Ngsa.Application.DataAccessLayer
         /// <param name="cosmosAuthType">CosmosDB Auth type</param>
         /// <returns>An open and validated CosmosClient</returns>
         private async Task<CosmosClient> OpenAndTestCosmosClient(string cosmosServer, string cosmosKey, string cosmosDatabase, string cosmosCollection, CosmosAuthType cosmosAuthType = CosmosAuthType.SecretKey)
-        {
-            // TODO: Do we want to have optional/default values for cosmosAuthType, since its a private method?
-            // validate required parameters
+        {            // validate required parameters
             if (cosmosServer == null)
             {
                 throw new ArgumentNullException(nameof(cosmosServer));

--- a/src/DataAccessLayer/dalMain.cs
+++ b/src/DataAccessLayer/dalMain.cs
@@ -88,7 +88,7 @@ namespace Ngsa.Application.DataAccessLayer
                 throw new ArgumentNullException(nameof(cosmosServer));
             }
 
-            if (string.IsNullOrWhiteSpace(cosmosKey))
+            if (cosmosAuthType == CosmosAuthType.SecretKey && string.IsNullOrWhiteSpace(cosmosKey))
             {
                 throw new ArgumentException(string.Format(CultureInfo.InvariantCulture, $"CosmosKey not set correctly {cosmosKey}"));
             }

--- a/src/DataAccessLayer/dalMain.cs
+++ b/src/DataAccessLayer/dalMain.cs
@@ -79,7 +79,7 @@ namespace Ngsa.Application.DataAccessLayer
         /// <param name="cosmosAuthType">CosmosDB Auth type</param>
         /// <returns>An open and validated CosmosClient</returns>
         private async Task<CosmosClient> OpenAndTestCosmosClient(string cosmosServer, string cosmosKey, string cosmosDatabase, string cosmosCollection, CosmosAuthType cosmosAuthType = CosmosAuthType.SecretKey)
-        {            // validate required parameters
+        {
             if (cosmosServer == null)
             {
                 throw new ArgumentNullException(nameof(cosmosServer));

--- a/src/DataAccessLayer/dalMain.cs
+++ b/src/DataAccessLayer/dalMain.cs
@@ -105,8 +105,8 @@ namespace Ngsa.Application.DataAccessLayer
 
             CosmosClient c = cosmosAuthType switch
             {
-                CosmosAuthType.SecretKey => new(cosmosServer, cosmosKey, cosmosDetails.CosmosClientOptions),
-                CosmosAuthType.ManagedIdentity or _ => new(cosmosServer, new DefaultAzureCredential(), cosmosDetails.CosmosClientOptions),
+                CosmosAuthType.ManagedIdentity => new(cosmosServer, new DefaultAzureCredential(), cosmosDetails.CosmosClientOptions),
+                CosmosAuthType.SecretKey or _ => new(cosmosServer, cosmosKey, cosmosDetails.CosmosClientOptions),
             };
 
             Container con = c.GetContainer(cosmosDatabase, cosmosCollection);

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -61,7 +61,7 @@ namespace Ngsa.Application
             else
             {
                 // We skip CosmosKey validation if we're using Managed Identity
-                Config.Secrets = Secrets.GetSecretsFromVolume(Config.SecretsVolume, Config.CosmosAuthType == CosmosAuthType.ManagedIdentity);
+                Config.Secrets = Secrets.GetSecretsFromVolume(Config.SecretsVolume, Config.CosmosAuthType);
 
                 // set the Cosmos server name for logging
                 Config.CosmosName = Config.Secrets.CosmosServer.Replace("https://", string.Empty, StringComparison.OrdinalIgnoreCase).Replace("http://", string.Empty, StringComparison.OrdinalIgnoreCase);

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -61,7 +61,7 @@ namespace Ngsa.Application
             else
             {
                 // We skip CosmosKey validation if we're using Managed Identity
-                Config.Secrets = Secrets.GetSecretsFromVolume(Config.SecretsVolume, Config.UseMIForCosmos);
+                Config.Secrets = Secrets.GetSecretsFromVolume(Config.SecretsVolume, Config.CosmosAuthType == CosmosAuthType.ManagedIdentity);
 
                 // set the Cosmos server name for logging
                 Config.CosmosName = Config.Secrets.CosmosServer.Replace("https://", string.Empty, StringComparison.OrdinalIgnoreCase).Replace("http://", string.Empty, StringComparison.OrdinalIgnoreCase);

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -60,9 +60,8 @@ namespace Ngsa.Application
             }
             else
             {
-                // We skip CosmosKey validation if we're using
-                bool skipCosmosKeyValidation = !Config.UseSecretKey;
-                Config.Secrets = Secrets.GetSecretsFromVolume(Config.SecretsVolume, skipCosmosKeyValidation);
+                // We skip CosmosKey validation if we're using Managed Identity
+                Config.Secrets = Secrets.GetSecretsFromVolume(Config.SecretsVolume, Config.UseMIForCosmos);
 
                 // set the Cosmos server name for logging
                 Config.CosmosName = Config.Secrets.CosmosServer.Replace("https://", string.Empty, StringComparison.OrdinalIgnoreCase).Replace("http://", string.Empty, StringComparison.OrdinalIgnoreCase);

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -60,7 +60,9 @@ namespace Ngsa.Application
             }
             else
             {
-                Config.Secrets = Secrets.GetSecretsFromVolume(Config.SecretsVolume);
+                // We skip CosmosKey validation if we're using
+                bool skipCosmosKeyValidation = !Config.UseSecretKey;
+                Config.Secrets = Secrets.GetSecretsFromVolume(Config.SecretsVolume, skipCosmosKeyValidation);
 
                 // set the Cosmos server name for logging
                 Config.CosmosName = Config.Secrets.CosmosServer.Replace("https://", string.Empty, StringComparison.OrdinalIgnoreCase).Replace("http://", string.Empty, StringComparison.OrdinalIgnoreCase);


### PR DESCRIPTION
# Type of PR

- [X] Documentation changes
- [X] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## Purpose of PR

- update resources to allow the NGSA-App to allow Cosmos to take advantage of Managed Identity
- Assure that the previous mechanism of using Cosmos keys still functions
- Update readme.md to illustrate changes

## Does this introduce a breaking change

- [ ] YES
- [X] NO

## Changes
| File Name | Change Made | 
| :----------  | :--------------  |
| Ngsa.App.csproj | Added Azure Identity package version 1.9.0-beta.1 |
| ReadMe.md | Added the parameters "--use-mi-for-cosmos" to the read me instructions |
| ngsa-cosmos.yaml | Added the parameter just added; --use-mi-for-cosmo |
| Commandline.cs | using Lucene.Net.Search reference added. |
| Commandline.cs | added the option for --use-mi-for-cosmos |
| Commandline.cs | Added the check to see if managed identity or Cosmos keys should be utilized.  |
| Core/Config.cs| added and enumeration named CosmosAuthType |
| Secrets.cs | added logic to handle if we should skipCosmosKey or not. |
| dalMain.cs | Added the Azure Identity package version 1.9.0-beta.1, Created Cosmos tests for authentication | 
| Program.cs | Updated to pass the Cosmos switch in | 

## Validation

- [ ] Unit tests updated and ran successfully
- [ ] Update documentation or issue referenced above


## Issues Closed or Referenced
- Closes https://github.com/retaildevcrews/wcnp/issues/1051

- References https://github.com/retaildevcrews/wcnp/issues/818
- References https://github.com/retaildevcrews/wcnp/issues/735
- References https://github.com/retaildevcrews/wcnp/issues/1052