### PR TITLE
Install .net 6.0 in on-create.sh

### DIFF
--- a/.devcontainer/on-create.sh
+++ b/.devcontainer/on-create.sh
@@ -36,7 +36,6 @@ docker network create k3d
 # Install dotnet-sdk-6.0, since by default sdk is dotnet-sdk-7.0
 sudo apt install -y --no-install-recommends dotnet-sdk-6.0
 
-
 # Create local container registry
 k3d registry create registry.localhost --port 5000
 

--- a/.devcontainer/on-create.sh
+++ b/.devcontainer/on-create.sh
@@ -33,6 +33,10 @@ hash istioctl || (echo "Installing istioctl" ; curl -sL https://istio.io/downloa
 # Create Docker Network for k3d
 docker network create k3d
 
+# Install dotnet-sdk-6.0, since by default sdk is dotnet-sdk-7.0
+sudo apt install -y --no-install-recommends dotnet-sdk-6.0
+
+
 # Create local container registry
 k3d registry create registry.localhost --port 5000
 


### PR DESCRIPTION
Added an install for .net 6.0 due to a base image update.

# Type of PR
- [ ] Documentation changes
- [X] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## PR Checklist
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code follows the code style of this project.
- [ ] I ran lint checks locally prior to submission.
- [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

## Purpose of PR
Due to an update to the base image used, currently only .net 5.0 and .net 7.0 are installed.  This allows for code to be built but not debugged.  I have added a .net 6.0 install to the on-create.sh 

## Does this introduce a breaking change

- [ ] YES
- [X] NO

## Validation
To validate the on-create.sh was modified in a branch, and then a codespace was created via that branch.  This solved the build/debug issues in codespaces.  

- [ ] Unit tests updated and ran successfully
- [ ] Update documentation or issue referenced above

## Issues Closed or Referenced

- Closes #1097
